### PR TITLE
Replace Zulip link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pretty Nice Framework
 
-[#prettynice]: https://discord.gg/dwbwjquy
+[#prettynice]: https://discord.gg/PuStSFDTch
 [Discord]: https://discord.gg/J8aaGMfz
 
 A purely functional, fully type-safe, full-stack web framework for [Gren](https://gren-lang.org/).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Pretty Nice Framework
 
+[#prettynice]: https://discord.gg/dwbwjquy
+[Discord]: https://discord.gg/J8aaGMfz
+
 A purely functional, fully type-safe, full-stack web framework for [Gren](https://gren-lang.org/).
 
 Your code runs on the server, but your responses can include fully-interactive, client-side components that run in the browser.
 Initialize those components with data server-side and you don't have to deal with loading states or data fetching errors.
 
-Follow [@blaix@hachyderm.io](https://hachyderm.io/@blaix) or check the [gren zulip](https://gren.zulipchat.com/) for updates.
+Follow [@blaix@hachyderm.io](https://hachyderm.io/@blaix) or check the [#prettynice][]
+channel on the Gren [Discord][] for updates.
 
 ## Table of Contents
 


### PR DESCRIPTION
* Create & add a direct invite link to the #prettynice Discord channel

* Add the "standard" invite link used the in the gren-lang/compiler repo

* Remove Zulip from the README